### PR TITLE
add dmatrix in csr format

### DIFF
--- a/benches/simple_bench.rs
+++ b/benches/simple_bench.rs
@@ -5,7 +5,15 @@ fn simple_bench(c: &mut Criterion) {
     let model = Predictor::load("examples/iris.so", 1).unwrap();
     let feat: Vec<f64> = vec![7.7, 2.8, 6.7, 2.];
     c.bench_function("simple", |b| {
-        b.iter(|| model.predict_batch::<_, f64>(&DMatrix::from_slice(black_box(&feat)).unwrap(), false, false).unwrap())
+        b.iter(|| {
+            model
+                .predict_batch::<_, f64>(
+                    &DMatrix::from_slice(black_box(&feat)).unwrap(),
+                    false,
+                    false,
+                )
+                .unwrap()
+        })
     });
 }
 

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,9 @@ fn main() {
 
 #[cfg(feature = "static")]
 fn build_lib() {
-    let dst = cmake::Config::new("treelite").define("BUILD_STATIC_LIBS", "ON").build();
+    let dst = cmake::Config::new("treelite")
+        .define("BUILD_STATIC_LIBS", "ON")
+        .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=treelite_runtime_static");
     println!("cargo:rustc-link-lib=stdc++");
@@ -22,7 +24,10 @@ fn build_lib() {
 
 #[cfg(not(target_os = "windows"))]
 fn add_search_path() {
-    for path in std::env::var("LD_LIBRARY_PATH").unwrap_or_else(|_| "".to_string()).split(":") {
+    for path in std::env::var("LD_LIBRARY_PATH")
+        .unwrap_or_else(|_| "".to_string())
+        .split(":")
+    {
         if path.trim().len() == 0 {
             continue;
         }
@@ -32,7 +37,10 @@ fn add_search_path() {
 
 #[cfg(target_os = "windows")]
 fn add_search_path() {
-    for path in std::env::var("PATH").unwrap_or_else(|_| "".to_string()).split(";") {
+    for path in std::env::var("PATH")
+        .unwrap_or_else(|_| "".to_string())
+        .split(";")
+    {
         if path.trim().len() == 0 {
             continue;
         }

--- a/src/dmatrix.rs
+++ b/src/dmatrix.rs
@@ -1,6 +1,10 @@
 use crate::errors::TreeRiteError;
 use crate::sys::DMatrixHandle;
-use crate::sys::{treelite_dmatrix_create_from_array, treelite_dmatrix_create_from_slice, treelite_dmatrix_create_from_csr_format, treelite_dmatrix_free, treelite_dmatrix_get_dimension, FloatInfo};
+use crate::sys::{
+    treelite_dmatrix_create_from_array, treelite_dmatrix_create_from_csr_format,
+    treelite_dmatrix_create_from_slice, treelite_dmatrix_free, treelite_dmatrix_get_dimension,
+    FloatInfo,
+};
 use fehler::throws;
 use ndarray::{AsArray, Ix2};
 use num_traits::Float;
@@ -28,7 +32,10 @@ where
         F: 'a,
     {
         let handle = treelite_dmatrix_create_from_array(array.into())?;
-        DMatrix { handle, _phantom: PhantomData }
+        DMatrix {
+            handle,
+            _phantom: PhantomData,
+        }
     }
 
     /// Create a single row DMatrix from a slice of floats. Useful for prediction for a single instance.
@@ -48,10 +55,12 @@ where
         num_row: u64,
         num_col: u64,
     ) -> DMatrix<F> {
-        let handle = treelite_dmatrix_create_from_csr_format(
-            headers, indices, data, num_row, num_col,
-        )?;
-        DMatrix { handle,  _phantom: PhantomData }
+        let handle =
+            treelite_dmatrix_create_from_csr_format(headers, indices, data, num_row, num_col)?;
+        DMatrix {
+            handle,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -74,7 +83,10 @@ impl<'a, F: Float + FloatInfo> TryInto<DMatrix<F>> for &'a [F] {
 
     fn try_into(self) -> Result<DMatrix<F>, Self::Error> {
         let handle = treelite_dmatrix_create_from_slice(self)?;
-        Ok(DMatrix { handle, _phantom: PhantomData })
+        Ok(DMatrix {
+            handle,
+            _phantom: PhantomData,
+        })
     }
 }
 

--- a/src/predictor.rs
+++ b/src/predictor.rs
@@ -1,9 +1,12 @@
 use crate::dmatrix::DMatrix;
 use crate::errors::TreeRiteError;
 use crate::sys::{
-    treelite_delete_predictor_output_vector, treelite_predictor_free, treelite_predictor_load, treelite_predictor_predict_batch, treelite_predictor_query_global_bias,
-    treelite_predictor_query_leaf_output_type, treelite_predictor_query_num_class, treelite_predictor_query_num_feature, treelite_predictor_query_pred_transform,
-    treelite_predictor_query_result_size, treelite_predictor_query_sigmoid_alpha, treelite_predictor_query_threshold_type, DataType, FloatInfo, PredictorHandle,
+    treelite_delete_predictor_output_vector, treelite_predictor_free, treelite_predictor_load,
+    treelite_predictor_predict_batch, treelite_predictor_query_global_bias,
+    treelite_predictor_query_leaf_output_type, treelite_predictor_query_num_class,
+    treelite_predictor_query_num_feature, treelite_predictor_query_pred_transform,
+    treelite_predictor_query_result_size, treelite_predictor_query_sigmoid_alpha,
+    treelite_predictor_query_threshold_type, DataType, FloatInfo, PredictorHandle,
 };
 use fehler::{throw, throws};
 use ndarray::{Array, Array2};
@@ -61,19 +64,28 @@ impl Predictor {
     /// # Note
     /// The output array should be explicitly typed, i.e. f64 or f32.
     #[throws(TreeRiteError)]
-    pub fn predict_batch<F, O>(&self, dmatrix: &DMatrix<F>, verbose: bool, pred_margin: bool) -> Array2<O>
+    pub fn predict_batch<F, O>(
+        &self,
+        dmatrix: &DMatrix<F>,
+        verbose: bool,
+        pred_margin: bool,
+    ) -> Array2<O>
     where
         O: Float + FloatInfo,
         F: Float + FloatInfo,
     {
         let dtype = self.leaf_output_type()?;
         let nclasses = self.num_class()?;
-        let (output, size) = treelite_predictor_predict_batch(self.handle, dmatrix.handle, verbose, pred_margin)?;
+        let (output, size) =
+            treelite_predictor_predict_batch(self.handle, dmatrix.handle, verbose, pred_margin)?;
         if dtype != O::DATA_TYPE {
             throw!(TreeRiteError::WrongPredictOutputType(O::DATA_TYPE))
         }
         let data = unsafe { from_raw_parts(output as *mut O, size as usize) };
-        let ret = Array::from_shape_vec((dmatrix.nrows()? as usize, nclasses as usize), data.to_vec())?;
+        let ret = Array::from_shape_vec(
+            (dmatrix.nrows()? as usize, nclasses as usize),
+            data.to_vec(),
+        )?;
 
         treelite_delete_predictor_output_vector(self.handle, output)?;
 

--- a/src/sys/dmatrix.rs
+++ b/src/sys/dmatrix.rs
@@ -1,5 +1,8 @@
-use super::bindings::{DMatrixHandle, TreeliteDMatrixCreateFromMat, TreeliteDMatrixCreateFromCSR, TreeliteDMatrixFree, TreeliteDMatrixGetDimension};
 use super::bindings::size_t;
+use super::bindings::{
+    DMatrixHandle, TreeliteDMatrixCreateFromCSR, TreeliteDMatrixCreateFromMat, TreeliteDMatrixFree,
+    TreeliteDMatrixGetDimension,
+};
 use super::{DataType, RetCodeCheck};
 use crate::errors::TreeRiteError;
 use fehler::{throw, throws};
@@ -31,7 +34,9 @@ impl FloatInfo for f32 {
 }
 
 #[throws(TreeRiteError)]
-pub fn treelite_dmatrix_create_from_array<'a, F: Float + FloatInfo>(data: ArrayView<'a, F, Ix2>) -> DMatrixHandle {
+pub fn treelite_dmatrix_create_from_array<'a, F: Float + FloatInfo>(
+    data: ArrayView<'a, F, Ix2>,
+) -> DMatrixHandle {
     if !data.is_standard_layout() {
         throw!(TreeRiteError::DataNotCContiguous);
     }
@@ -51,7 +56,9 @@ pub fn treelite_dmatrix_create_from_array<'a, F: Float + FloatInfo>(data: ArrayV
 }
 
 #[throws(TreeRiteError)]
-pub fn treelite_dmatrix_create_from_slice<'a, T: Float + FloatInfo>(data: &'a [T]) -> DMatrixHandle {
+pub fn treelite_dmatrix_create_from_slice<'a, T: Float + FloatInfo>(
+    data: &'a [T],
+) -> DMatrixHandle {
     let mut out = null_mut();
     unsafe {
         TreeliteDMatrixCreateFromMat(
@@ -74,7 +81,7 @@ pub fn treelite_dmatrix_create_from_csr_format<'a, T: Float + FloatInfo>(
     data: &'a [T],
     num_row: u64,
     num_col: u64,
-) -> DMatrixHandle{
+) -> DMatrixHandle {
     let mut out = null_mut();
     unsafe {
         TreeliteDMatrixCreateFromCSR(
@@ -86,7 +93,8 @@ pub fn treelite_dmatrix_create_from_csr_format<'a, T: Float + FloatInfo>(
             num_col,
             &mut out,
         )
-    }.check()?;
+    }
+    .check()?;
     out
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -4,11 +4,18 @@ mod predictor;
 
 pub use self::bindings::{DMatrixHandle, PredictorHandle, PredictorOutputHandle};
 use self::bindings::{TreeliteGetLastError, TreeliteRegisterLogCallback};
-pub use self::dmatrix::{treelite_dmatrix_create_from_array, treelite_dmatrix_create_from_slice, treelite_dmatrix_create_from_csr_format, treelite_dmatrix_free, treelite_dmatrix_get_dimension, FloatInfo};
+pub use self::dmatrix::{
+    treelite_dmatrix_create_from_array, treelite_dmatrix_create_from_csr_format,
+    treelite_dmatrix_create_from_slice, treelite_dmatrix_free, treelite_dmatrix_get_dimension,
+    FloatInfo,
+};
 pub use self::predictor::{
-    treelite_create_predictor_output_vector, treelite_delete_predictor_output_vector, treelite_predictor_free, treelite_predictor_load, treelite_predictor_predict_batch,
-    treelite_predictor_query_global_bias, treelite_predictor_query_leaf_output_type, treelite_predictor_query_num_class, treelite_predictor_query_num_feature,
-    treelite_predictor_query_pred_transform, treelite_predictor_query_result_size, treelite_predictor_query_sigmoid_alpha, treelite_predictor_query_threshold_type,
+    treelite_create_predictor_output_vector, treelite_delete_predictor_output_vector,
+    treelite_predictor_free, treelite_predictor_load, treelite_predictor_predict_batch,
+    treelite_predictor_query_global_bias, treelite_predictor_query_leaf_output_type,
+    treelite_predictor_query_num_class, treelite_predictor_query_num_feature,
+    treelite_predictor_query_pred_transform, treelite_predictor_query_result_size,
+    treelite_predictor_query_sigmoid_alpha, treelite_predictor_query_threshold_type,
 };
 use crate::errors::TreeRiteError;
 use fehler::{throw, throws};
@@ -82,7 +89,9 @@ impl TryInto<DataType> for &'static CStr {
         } else if self == DTYPE_UINT32 {
             Ok(DataType::UInt32)
         } else {
-            throw!(TreeRiteError::UnknownDataTypeString(self.to_string_lossy().to_owned().to_string()))
+            throw!(TreeRiteError::UnknownDataTypeString(
+                self.to_string_lossy().to_owned().to_string()
+            ))
         }
     }
 }

--- a/src/sys/predictor.rs
+++ b/src/sys/predictor.rs
@@ -1,7 +1,11 @@
 use super::bindings::{
-    DMatrixHandle, PredictorHandle, PredictorOutputHandle, TreeliteCreatePredictorOutputVector, TreeliteDeletePredictorOutputVector, TreelitePredictorFree, TreelitePredictorLoad,
-    TreelitePredictorPredictBatch, TreelitePredictorQueryGlobalBias, TreelitePredictorQueryLeafOutputType, TreelitePredictorQueryNumClass, TreelitePredictorQueryNumFeature,
-    TreelitePredictorQueryPredTransform, TreelitePredictorQueryResultSize, TreelitePredictorQuerySigmoidAlpha, TreelitePredictorQueryThresholdType,
+    DMatrixHandle, PredictorHandle, PredictorOutputHandle, TreeliteCreatePredictorOutputVector,
+    TreeliteDeletePredictorOutputVector, TreelitePredictorFree, TreelitePredictorLoad,
+    TreelitePredictorPredictBatch, TreelitePredictorQueryGlobalBias,
+    TreelitePredictorQueryLeafOutputType, TreelitePredictorQueryNumClass,
+    TreelitePredictorQueryNumFeature, TreelitePredictorQueryPredTransform,
+    TreelitePredictorQueryResultSize, TreelitePredictorQuerySigmoidAlpha,
+    TreelitePredictorQueryThresholdType,
 };
 use super::{DataType, RetCodeCheck};
 use crate::errors::TreeRiteError;
@@ -17,7 +21,8 @@ pub fn treelite_predictor_load(library_path: &Path, num_worker_thread: usize) ->
     let library_path = CString::new(library_path.to_string_lossy().to_owned().to_string())?;
     let mut out = null_mut();
 
-    unsafe { TreelitePredictorLoad(library_path.as_ptr(), num_worker_thread as c_int, &mut out) }.check()?;
+    unsafe { TreelitePredictorLoad(library_path.as_ptr(), num_worker_thread as c_int, &mut out) }
+        .check()?;
 
     out
 }
@@ -28,13 +33,28 @@ pub fn treelite_predictor_free(handle: PredictorHandle) {
 }
 
 #[throws(TreeRiteError)]
-pub fn treelite_predictor_predict_batch(handle: PredictorHandle, batch: DMatrixHandle, verbose: bool, pred_margin: bool) -> (PredictorOutputHandle, u64) {
+pub fn treelite_predictor_predict_batch(
+    handle: PredictorHandle,
+    batch: DMatrixHandle,
+    verbose: bool,
+    pred_margin: bool,
+) -> (PredictorOutputHandle, u64) {
     let verbose = if verbose { 1 } else { 0 };
     let pred_margin = if pred_margin { 1 } else { 0 };
     let output_result = treelite_create_predictor_output_vector(handle, batch)?;
     let mut out_result_size = 0;
 
-    unsafe { TreelitePredictorPredictBatch(handle, batch, verbose, pred_margin, output_result, &mut out_result_size) }.check()?;
+    unsafe {
+        TreelitePredictorPredictBatch(
+            handle,
+            batch,
+            verbose,
+            pred_margin,
+            output_result,
+            &mut out_result_size,
+        )
+    }
+    .check()?;
 
     (output_result, out_result_size)
 }
@@ -98,7 +118,10 @@ pub fn treelite_predictor_query_pred_transform(handle: PredictorHandle) -> Strin
 
     unsafe { TreelitePredictorQueryPredTransform(handle, &mut out) }.check()?;
 
-    unsafe { CStr::from_ptr(out) }.to_string_lossy().to_owned().to_string()
+    unsafe { CStr::from_ptr(out) }
+        .to_string_lossy()
+        .to_owned()
+        .to_string()
 }
 
 #[throws(TreeRiteError)]
@@ -107,11 +130,17 @@ pub fn treelite_predictor_query_threshold_type(handle: PredictorHandle) -> Strin
 
     unsafe { TreelitePredictorQueryThresholdType(handle, &mut out) }.check()?;
 
-    unsafe { CStr::from_ptr(out) }.to_string_lossy().to_owned().to_string()
+    unsafe { CStr::from_ptr(out) }
+        .to_string_lossy()
+        .to_owned()
+        .to_string()
 }
 
 #[throws(TreeRiteError)]
-pub fn treelite_create_predictor_output_vector(handle: PredictorHandle, batch: DMatrixHandle) -> PredictorOutputHandle {
+pub fn treelite_create_predictor_output_vector(
+    handle: PredictorHandle,
+    batch: DMatrixHandle,
+) -> PredictorOutputHandle {
     let mut out = null_mut();
 
     unsafe { TreeliteCreatePredictorOutputVector(handle, batch, &mut out) }.check()?;
@@ -120,6 +149,9 @@ pub fn treelite_create_predictor_output_vector(handle: PredictorHandle, batch: D
 }
 
 #[throws(TreeRiteError)]
-pub fn treelite_delete_predictor_output_vector(handle: PredictorHandle, output_vector: PredictorOutputHandle) {
+pub fn treelite_delete_predictor_output_vector(
+    handle: PredictorHandle,
+    output_vector: PredictorOutputHandle,
+) {
     unsafe { TreeliteDeletePredictorOutputVector(handle, output_vector) }.check()?;
 }

--- a/tests/dmatrix.rs
+++ b/tests/dmatrix.rs
@@ -38,7 +38,7 @@ fn dmatrix_from_2darray() {
 }
 
 #[test]
-fn dmatrix_from_csr_format(){
+fn dmatrix_from_csr_format() {
     // this sample is from https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
     let data = vec![10f32, 20f32, 30f32, 40f32, 50f32, 60f32, 70f32, 80f32];
     let indices = vec![0, 1, 1, 3, 2, 3, 4, 5];

--- a/tests/predictor.rs
+++ b/tests/predictor.rs
@@ -25,7 +25,9 @@ fn query_result_size() {
         [6.5, 2.8, 4.6, 1.5]
     ];
     assert_eq!(
-        model.result_size(&DMatrix::from_2darray(&feats).unwrap()).unwrap(),
+        model
+            .result_size(&DMatrix::from_2darray(&feats).unwrap())
+            .unwrap(),
         feats.nrows() as u64 * model.num_class().unwrap()
     );
 }
@@ -72,9 +74,14 @@ fn single_row_predict() {
 
     let feat = vec![5.4, 3.7, 1.5, 0.2];
 
-    let pred: Array2<f64> = model.predict_batch(&DMatrix::from_slice(&feat).unwrap(), false, false).unwrap();
+    let pred: Array2<f64> = model
+        .predict_batch(&DMatrix::from_slice(&feat).unwrap(), false, false)
+        .unwrap();
 
-    assert_eq!(pred, array![[0.7979739007026813, 0.1002914545900944, 0.10173464470722438]]);
+    assert_eq!(
+        pred,
+        array![[0.7979739007026813, 0.1002914545900944, 0.10173464470722438]]
+    );
 }
 
 #[test]
@@ -106,7 +113,9 @@ fn multi_row_predict() {
         [6.5, 2.8, 4.6, 1.5]
     ];
 
-    let pred: Array2<f64> = model.predict_batch(&DMatrix::from_2darray(&feat).unwrap(), false, false).unwrap();
+    let pred: Array2<f64> = model
+        .predict_batch(&DMatrix::from_2darray(&feat).unwrap(), false, false)
+        .unwrap();
 
     assert_eq!(
         pred,


### PR DESCRIPTION
I use this wonderful library. In this library, the missing value is NaN, but in my use case, I want to use the missing value as 0. This is because I use DMatrix in CSR format to train my model in XGBoost.
I also need the CSR format for treerite. Therefore, I have implemented DMatrix in CSR format. I am a beginner in Rust. I would appreciate your advice and comments.