### PR TITLE
Build compatibility for Linux OSs with LIBDIR=lib64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() {
 fn build_lib() {
     let dst = cmake::Config::new("treelite")
         .define("BUILD_STATIC_LIBS", "ON")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=treelite_runtime_static");
@@ -17,7 +18,9 @@ fn build_lib() {
 
 #[cfg(feature = "dynamic")]
 fn build_lib() {
-    let dst = cmake::Config::new("treelite").build();
+    let dst = cmake::Config::new("treelite")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+        .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:rustc-link-lib=dynamic=treelite_runtime");
 }

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn build_lib() {
         .define("CMAKE_INSTALL_LIBDIR", "lib")
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
-    println!("cargo:rustc-link-lib=dynamic=treelite_runtime");
+    println!("cargo:rustc-link-lib=dylib=treelite_runtime");
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Amazing work on this treerite crate! 

**Problem:**
Building on Amazon Linux 2/other RedHat-derived distros (x86-64) failed because the default `CMAKE_INSTALL_LIBDIR=lib64`. I'm not familiar with CMake, but this dir is `lib` by default for Ubuntu but `lib64` for other distros—it seems very case-by-case. 

As a result, the search directory (`/path/to/cargo/project/target/debug/build/treerite-49cc21405edc7651/out/lib`) as defined in line 12 of `build.rs`  doesn't exist _under that name_; the library is in `.../out/lib64`.  

_Error message:_
```
   Compiling treerite v0.1.3 (https://github.com/dovahcrow/treerite#893d6e90)
     Running `rustc --crate-name treerite --edition=2018 /home/ec2-user/.cargo/git/checkouts/treerite-60cb798f712ec7e5/893d6e9/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="free_panic"' --cfg 'feature="static"' -C metadata=0e14c6fb393d182b -C extra-filename=-0e14c6fb393d182b --out-dir /path/to/cargo/project/target/debug/deps -L dependency=/path/to/cargo/project/target/debug/deps --extern [...] --cap-lints allow -L /path/to/cargo/project/target/debug/deps -L /path/to/cargo/project/target/debug -L /home/ec2-user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib -L /home/ec2-user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib -L /path/to/cargo/project/target/debug/build/treerite-49cc21405edc7651/out/lib -l static=treelite_runtime_static -l stdc++ -l gomp`
error: could not find native static library `treelite_runtime_static`, perhaps an -L flag is missing?
```

**Solution:**
We can standardize CMAKE_INSTALL_LIBDIR to compile into `lib` as an additional `-D` flag to CMake in lines 9 & 21 of `build.rs`.
```
let dst = cmake::Config::new("treelite")
        .define("BUILD_STATIC_LIBS", "ON")
        .define("CMAKE_INSTALL_LIBDIR", "lib") <<<<
        .build();
```

**Also:** The dynamic library did not build, switching dynamic—>dylib fixes that. (see [Cargo Book](https://doc.rust-lang.org/cargo/reference/build-scripts.html#:~:text=The%20optional%20KIND%20may%20be%20one%20of%20dylib%2C%20static%2C%20or%20framework.))