### PR TITLE
update treelite to 2.1.0 and fix msvc build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ fn build_lib() {
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=treelite_runtime_static");
+    #[cfg(not(target_os = "windows"))]
     println!("cargo:rustc-link-lib=stdc++");
     println!("cargo:rustc-link-lib=gomp");
 }

--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,11 @@ fn build_lib() {
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=treelite_runtime_static");
-    #[cfg(not(target_os = "windows"))]
-    println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=gomp");
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=stdc++");
+        println!("cargo:rustc-link-lib=gomp");
+    }
 }
 
 #[cfg(feature = "dynamic")]

--- a/build.rs
+++ b/build.rs
@@ -10,22 +10,14 @@ fn build_lib() {
         .define("BUILD_STATIC_LIBS", "ON")
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
+    println!("cargo:rustc-link-lib=static=treelite_runtime_static");
     #[cfg(target_os = "linux")]
     {
-        println!("cargo:rustc-link-lib=static=treelite_runtime_static");
         println!("cargo:rustc-link-lib=stdc++");
-        println!("cargo:rustc-link-lib=gomp");
     }
     #[cfg(target_os = "macos")]
     {
-        println!("cargo:rustc-link-lib=static=treelite_runtime_static");
         println!("cargo:rustc-link-lib=c++");
-        println!("cargo:rustc-link-lib=omp");
-    }
-    #[cfg(target_os = "windows")]
-    {
-        println!("cargo:rustc-link-lib=static=treelite_runtime");
-        //println!("cargo:rustc-link-lib=omp");
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -10,20 +10,22 @@ fn build_lib() {
         .define("BUILD_STATIC_LIBS", "ON")
         .build();
     println!("cargo:rustc-link-search={}/lib", dst.display());
-    println!("cargo:rustc-link-lib=static=treelite_runtime_static");
     #[cfg(target_os = "linux")]
     {
+        println!("cargo:rustc-link-lib=static=treelite_runtime_static");
         println!("cargo:rustc-link-lib=stdc++");
         println!("cargo:rustc-link-lib=gomp");
     }
     #[cfg(target_os = "macos")]
     {
+        println!("cargo:rustc-link-lib=static=treelite_runtime_static");
         println!("cargo:rustc-link-lib=c++");
         println!("cargo:rustc-link-lib=omp");
     }
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=omp");
+        println!("cargo:rustc-link-lib=static=treelite_runtime");
+        //println!("cargo:rustc-link-lib=omp");
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,15 @@ fn build_lib() {
         println!("cargo:rustc-link-lib=stdc++");
         println!("cargo:rustc-link-lib=gomp");
     }
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=c++");
+        println!("cargo:rustc-link-lib=omp");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        println!("cargo:rustc-link-lib=omp");
+    }
 }
 
 #[cfg(feature = "dynamic")]


### PR DESCRIPTION
treelite 2.0+ reduced dependencies: dmlc-core/opemmp.